### PR TITLE
Right tree table: moved "set as top artifact" functionality from rowSelection event to separate button

### DIFF
--- a/artifacts/Application/devinfo_overview/devinfo_overview.json
+++ b/artifacts/Application/devinfo_overview/devinfo_overview.json
@@ -1391,7 +1391,7 @@
 																				{
 																					"attribute": "width",
 																					"grouping": "Properties",
-																					"value": "50px",
+																					"value": "90px",
 																					"script": "",
 																					"translation": []
 																				},
@@ -1413,8 +1413,58 @@
 																					"customComponent": false,
 																					"request": [],
 																					"response": [],
-																					"attributes": [],
+																					"attributes": [
+																						{
+																							"attribute": "justifyContent",
+																							"grouping": "Properties",
+																							"value": "SpaceBetween",
+																							"script": "",
+																							"translation": []
+																						}
+																					],
 																					"data": [
+																						{
+																							"fieldNo": "95437455-bfb5-4210-9c3b-a0f2425d87e3",
+																							"fieldName": "ButtonSetForShowUsage",
+																							"fieldParent": "e3fb243c-3f41-4fa4-cd97-58bf5317d556",
+																							"fieldType": "sap.m.Button",
+																							"script": "",
+																							"customComponent": false,
+																							"request": [],
+																							"response": [],
+																							"attributes": [
+																								{
+																									"attribute": "type",
+																									"grouping": "Properties",
+																									"value": "Transparent",
+																									"script": "",
+																									"translation": []
+																								},
+																								{
+																									"attribute": "tooltip",
+																									"grouping": "Properties",
+																									"value": "Set as top artifact",
+																									"script": "",
+																									"translation": []
+																								},
+																								{
+																									"attribute": "icon",
+																									"grouping": "Properties",
+																									"value": "sap-icon://back-to-top",
+																									"script": "",
+																									"translation": []
+																								},
+																								{
+																									"attribute": "press",
+																									"grouping": "Events",
+																									"value": "Anonymous Function",
+																									"script": "showUsage(oEvent);",
+																									"language": "javascript",
+																									"translation": []
+																								}
+																							],
+																							"data": []
+																						},
 																						{
 																							"fieldNo": "9439cf87-ff79-4564-e5c3-0a2548b5679f",
 																							"fieldName": "Button6",
@@ -4428,7 +4478,7 @@
 		}
 	],
 	"componentInterface": [],
-	"ver": "24.06.11.0748",
+	"ver": "24.06.11.0840",
 	"application": "devinfo_overview",
 	"title": "Development Infosystem",
 	"description": "Development Infosystem",

--- a/artifacts/Application/devinfo_overview/devinfo_overview.json
+++ b/artifacts/Application/devinfo_overview/devinfo_overview.json
@@ -4428,7 +4428,7 @@
 		}
 	],
 	"componentInterface": [],
-	"ver": "23.11.20.2053",
+	"ver": "24.06.11.0748",
 	"application": "devinfo_overview",
 	"title": "Development Infosystem",
 	"description": "Development Infosystem",

--- a/artifacts/Application/devinfo_overview/event/sap.ui.table.TreeTable/whereUsedTree/rowSelectionChange.js
+++ b/artifacts/Application/devinfo_overview/event/sap.ui.table.TreeTable/whereUsedTree/rowSelectionChange.js
@@ -1,2 +1,2 @@
-showUsage(oEvent);
+// showUsage(oEvent);
 //navigateArtifactTree(oEvent);

--- a/artifacts/Application/devinfo_overview/script/neptune.Script/Scripts/whereUsedEvent.js
+++ b/artifacts/Application/devinfo_overview/script/neptune.Script/Scripts/whereUsedEvent.js
@@ -1,5 +1,5 @@
 function showUsage(event) {
-    let context = event.getParameter("rowContext");
+    let context = event.getParameter("rowContext") || event.getSource().getBindingContext();
     if (!context) {
         return;
     }

--- a/artifacts/Jobs/Create Development Infosystem Snapshot.json
+++ b/artifacts/Jobs/Create Development Infosystem Snapshot.json
@@ -27,6 +27,6 @@
 	"stopdate": "9999-12-31T00:00:00.000Z",
 	"executeInNextCycle": false,
 	"ver": "23.8.28.116",
-	"machineId": "5da1af28090690bd202e57da492d5f74c9db5b19bdab923aac98d07e5502f3b1",
+	"machineId": "08634bfd04ea3cfd06aa70fed5cba198f8b88933369f9924656ea68a15080890",
 	"package": "93e1803f-3404-ee11-907c-000d3aba433d"
 }

--- a/artifacts/dev_package.json
+++ b/artifacts/dev_package.json
@@ -3,11 +3,11 @@
 	"createdAt": "2023-06-06T06:34:55.573Z",
 	"createdBy": "jens-uwe.gross@neptune-software.com",
 	"git": {
-		"remote": "https://github.com/neptune-software-marketplace/neptunesoftware-dxp-abb-devinfo.git"
+		"remote": "https://github.com/CASTANA-Solutions/neptunesoftware-dxp-abb-devinfo.git"
 	},
 	"name": "neptunesoftware-dxp-abb-devinfo",
 	"description": "Neptune DXP Open Edition Development Infosystem",
-	"ver": "23.8.14.1421",
+	"ver": "24.06.11.0749",
 	"enableCICD": true,
 	"apps": [
 		{
@@ -16,7 +16,7 @@
 			"title": "Development Infosystem",
 			"description": "Development Infosystem",
 			"package": {
-				"id": "93E1803F-3404-EE11-907C-000D3ABA433D"
+				"id": "93e1803f-3404-ee11-907c-000d3aba433d"
 			}
 		}
 	],


### PR DESCRIPTION
When opening/closing nodes in the tree it can easily happen that you click on the row and not the arrow. This will select the artifact from this row as new "top artifact" for the usage tree, changing its data completely.

Proposal: instead of the rowSelection event (to avoid this mis-clicks), use a separate button for this functionality.

![image](https://github.com/neptune-software-marketplace/neptunesoftware-dxp-abb-devinfo/assets/2165142/c82f9d46-3544-4fe7-8bdf-df5b165f4dae)
